### PR TITLE
Fix #46: Wrong parameter type for Invoke-ImEvent event parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## [0.0.27] - 2025-02-11
+
+### Fixes
+
+- Fix issue #46: Wrong parameter type for Invoke-ImEvent event parameters
+
+### Testing
+
+- Add test case for generating events with parameters
+
+### Miscellaneous
+
 ## [0.0.26] - 2025-01-27
 
 ### Fixes

--- a/PSIdentityManagerUtils/PSIdentityManagerUtils.psd1
+++ b/PSIdentityManagerUtils/PSIdentityManagerUtils.psd1
@@ -6,7 +6,7 @@
 
     RootModule = 'PSIdentityManagerUtils.psm1'
 
-    ModuleVersion = '0.0.26'
+    ModuleVersion = '0.0.27'
 
     Guid = 'a9a73145-c9e6-43c9-8dc9-0ab4831da948'
 

--- a/PSIdentityManagerUtils/Public/Get-ImEvent.ps1
+++ b/PSIdentityManagerUtils/Public/Get-ImEvent.ps1
@@ -49,7 +49,9 @@
       $entityCollection = $src.GetCollectionAsync($query, [VI.DB.Entities.EntityCollectionLoadType]::Slim, $noneToken).GetAwaiter().GetResult()
 
       ForEach ($e in $entityCollection) {
-        Get-EntityColumnValue -Entity $e -Column 'EventName'
+        $eventName = Get-EntityColumnValue -Entity $e -Column 'EventName'
+
+        $eventName
       }
     } catch {
       Resolve-Exception -ExceptionObject $PSitem

--- a/PSIdentityManagerUtils/Public/Invoke-ImEvent.ps1
+++ b/PSIdentityManagerUtils/Public/Invoke-ImEvent.ps1
@@ -18,7 +18,7 @@
     [string] $Identity,
     [Parameter(Mandatory = $true, HelpMessage = 'The eventname to generate')]
     [ValidateNotNullOrEmpty()]
-    [String] $EventName,
+    [string] $EventName,
     [Parameter(Mandatory = $false, HelpMessage = 'The parameter key value pairs for the event')]
     [Hashtable] $EventParameters
   )
@@ -44,7 +44,14 @@
       $uow = New-UnitOfWork -Session $sessionToUse
 
       try {
-        ($uow).GenerateAsync($Entity, $EventName, $EventParameters, $noneToken).GetAwaiter().GetResult() | Out-Null
+        $ep = New-Object 'System.Collections.Generic.Dictionary[string, object]'
+        if ($EventParameters) {
+          foreach ($key in $EventParameters.Keys) {
+              $ep.Add($key, $EventParameters[$key])
+          }
+        }
+
+        ($uow).GenerateAsync($Entity, $EventName, $ep, $noneToken).GetAwaiter().GetResult() | Out-Null
       }
       catch {
         Resolve-Exception -ExceptionObject $PSitem

--- a/Tests/Entity.Tests.ps1
+++ b/Tests/Entity.Tests.ps1
@@ -248,11 +248,27 @@ Describe 'Entity' {
             $events | Should -Not -BeNullOrEmpty
         }
 
-        It 'Can fire event' {
+        It 'Can fire event I' {
             $randomLastName = [String][System.Guid]::NewGuid()
             $pO = New-Entity -Type 'Person' -Properties @{'FirstName' = 'Max'; 'LastName' = $randomLastName; 'EntryDate' = [DateTime]::Today.AddDays(-10)}
 
             { Invoke-ImEvent $pO -EventName 'CHECK_EXITDATE'} | Should -Not -Throw
+
+            Remove-Entity -Type 'Person' -Identity ($pO).UID_Person -IgnoreDeleteDelay | Out-Null
+        }
+
+        It 'Can fire event II' {
+            # This test will only pass on a database WITHOUT active mail delivery.
+
+            $randomLastName = [String][System.Guid]::NewGuid()
+            $pO = New-Entity -Type 'Person' -Properties @{'FirstName' = 'Max'; 'LastName' = $randomLastName; 'DefaultEmailAddress' = 'foobar@test.local'}
+
+            {
+                $params = @{
+                    PwdErrors = 'FooBar'
+                }
+                Invoke-ImEvent $pO -EventName 'PwdError' -EventParameters $params
+            } | Should -Throw '*Error generating processes for event PwdError.*'
 
             Remove-Entity -Type 'Person' -Identity ($pO).UID_Person -IgnoreDeleteDelay | Out-Null
         }


### PR DESCRIPTION
Invoke-ImEvent still has Hashtable as datatype for parameter but this get converted internally to [System.Collections.Generic.Dictionary[string,System.Object]] as in PowerShell the handling with a hashtable is more convenient.